### PR TITLE
Safari and Mozilla error: ...in a lexically nested statement

### DIFF
--- a/src/ng-youtube-embed.js
+++ b/src/ng-youtube-embed.js
@@ -35,18 +35,7 @@ angular.module('ngYoutubeEmbed', []).directive('ngYoutubeEmbed', [function() {
             var link = $scope.url;
 
             if (link != undefined) {
-                // Function to fetch id from youtube link
-                function fetchId(link) {
-                    var p = /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
-                    var q = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
-                    var match = link.match(q);
-                    var id = link.match(p);
-                    if (id != null) {
-                        var ytId = id[1];
-                        return ytId;
-                    }
-                }
-
+                
                 // Detecting playlist and fetching video ids
                 $scope.playlistArray = [];
                 if ($scope.playlist != undefined) {
@@ -97,6 +86,18 @@ angular.module('ngYoutubeEmbed', []).directive('ngYoutubeEmbed', [function() {
                 var iframe = '<iframe width='+width+' height='+height+' src="https://www.youtube.com/embed/' + ytId + '?autoplay=' + autoplay + '&autohide=' + autohide + '&cc_load_policy=' + ccloadpolicy + '&color=' + color + '&controls=' + controls + '&disablekb=' + disablekb + '&end=' + end + '&fs=' + fs + '&hl=' + hl + '&playlist=' + playlist + '&playsinline=' + playsinline + '&rel=' + rel + '&showinfo=' + showinfo + '&start=' + start + '&theme=' + theme + '" frameborder="0" allowfullscreen></iframe>';
                 // Sanitizing and rendering iframe
                 $scope.youtubeEmbedFrame = $sce.trustAsHtml(iframe);
+            }
+
+            // Function to fetch id from youtube link
+            function fetchId(link) {
+                var p = /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
+                var q = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
+                var match = link.match(q);
+                var id = link.match(p);
+                if (id != null) {
+                    var ytId = id[1];
+                    return ytId;
+                }
             }
         }]
     }


### PR DESCRIPTION
Hi @ArunMichaelDsouza 
I found an error in safari and mozilla related with the 'strict mode' is interpreted for this couple a browsers, they are giving the follow error:
![captura de pantalla 2016-06-21 a las 9 42 14 a m](https://cloud.githubusercontent.com/assets/1288502/16234947/aee8eca0-3798-11e6-832b-57fda3373468.png)

I,ve test it and It's working fine in Chrome, Mozilla and Safari now
Any comments please let me know
