### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AngularJS module to embed Youtube videos with support for Youtube player paramet
 Use ng-youtube-embed directly from jsdelivr CDN
 
 ```html
-https://cdn.jsdelivr.net/angular.youtube-embed/1.7.10/ng-youtube-embed.min.js
+https://cdn.jsdelivr.net/npm/ng-youtube-embed@1.7.10/build/ng-youtube-embed.min.js
 ```
 
 #### via bower


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/ng-youtube-embed.

Feel free to ping me if you have any questions regarding this change.